### PR TITLE
Fix authorized? method

### DIFF
--- a/lib/heroku-resque-workers-scaler/scaler.rb
+++ b/lib/heroku-resque-workers-scaler/scaler.rb
@@ -44,7 +44,7 @@ module HerokuResqueAutoScale
       private
       
       def authorised?
-        HerokuResqueAutoScale::Config.thresholds.include? Rails.env.to_s
+        HerokuResqueAutoScale::Config.environments.include? Rails.env.to_s
       end
         
     end


### PR DESCRIPTION
It seems like `thresholds` method is not the one you wanted to use.

I replaced it by `environments` method.
