### PR TITLE
add missing return for test mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changelog  VERSION = '0.3.2'
+
+* bug fix
+  * missing one return to avoid connection on forbidden mode.
+
+[Fullcahnges](https://github.com/joel/heroku-resque-workers-scaler/pull/10)
+
 # Changelog  VERSION = '0.3.1'
 
 * bug fix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heroku-resque-workers-scaler (0.3.1)
+    heroku-resque-workers-scaler (0.3.2)
       platform-api (~> 0.2.0)
       resque (~> 1.25.2)
 

--- a/lib/heroku-resque-workers-scaler/scaler.rb
+++ b/lib/heroku-resque-workers-scaler/scaler.rb
@@ -29,6 +29,7 @@ module HerokuResqueAutoScale
       end
 
       def shut_down_workers!
+        return unless authorized?
         @@heroku.formation.update(app_name, worker_name, { quantity: 0 })
         nil
       end

--- a/lib/heroku-resque-workers-scaler/version.rb
+++ b/lib/heroku-resque-workers-scaler/version.rb
@@ -1,3 +1,3 @@
 module HerokuResqueAutoScale
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
# Changelog  VERSION = '0.3.2'
- bug fix
  - missing one return to avoid connection on forbidden mode.

[Fullcahnges](https://github.com/joel/heroku-resque-workers-scaler/pull/10)
