### PR TITLE
Deactivation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changelog  VERSION = '0.3.4'
+
+* feature
+  * Add quick deactvation mode
+
 # Changelog  VERSION = '0.3.3'
 
 * feature

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heroku-resque-workers-scaler (0.3.3)
+    heroku-resque-workers-scaler (0.3.4)
       platform-api (~> 0.2.0)
       resque (~> 1.25.2)
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ When you ask heroku for scale down workers, heroku send SIGTERM and wait 4 secon
 ```
 	heroku config:add SAFE_MODE=true -a your_app_name
 ```
+
+#### Quick deactivation mode
+
+If you want turn off quickly this feature, you can make this
+```
+  heroku config:add RESQUE_AUTO_SCALE=deactivate -a your_app_name
+```
+
+for turn on just remove this config
+
+```
+  heroku config:remove RESQUE_AUTO_SCALE -a your_app_name
+```
+
 ## Contributing to heroku-resque-workers-scaler
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/lib/heroku-resque-workers-scaler/scaler.rb
+++ b/lib/heroku-resque-workers-scaler/scaler.rb
@@ -69,7 +69,8 @@ module HerokuResqueAutoScale
       private
 
       def authorized?
-        Config.environments.include? _environment
+        return false if (ENV['RESQUE_AUTO_SCALE'] && ENV['RESQUE_AUTO_SCALE'] == 'deactivate')
+        Config.environments.include?(_environment)
       end
 
       def _environment

--- a/lib/heroku-resque-workers-scaler/version.rb
+++ b/lib/heroku-resque-workers-scaler/version.rb
@@ -1,3 +1,3 @@
 module HerokuResqueAutoScale
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end


### PR DESCRIPTION
# Changelog  VERSION = '0.3.4'
- feature
  - Add quick deactivation mode
# Quick deactivation mode

If you want turn off quickly this feature, you can make this

```
  heroku config:add RESQUE_AUTO_SCALE=deactivate -a your_app_name
```

for turn on just remove this config

```
  heroku config:remove RESQUE_AUTO_SCALE -a your_app_name
```
